### PR TITLE
Feat/#7 user

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 
     implementation files('../libs/msa-common-security-1.0.4-plain.jar')
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 clean {

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    implementation files('../libs/msa-common-security-1.0.4-plain.jar')
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 }
 
 clean {

--- a/src/main/java/app/UserApplication.java
+++ b/src/main/java/app/UserApplication.java
@@ -2,8 +2,19 @@ package app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
+@ComponentScan(
+	basePackages = "app",
+	excludeFilters = @ComponentScan.Filter(
+		type = FilterType.ASSIGNABLE_TYPE,
+		classes = app.commonSecurity.config.SecurityConfig.class
+	)
+)
 public class UserApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/app/UserApplication.java
+++ b/src/main/java/app/UserApplication.java
@@ -5,8 +5,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
+@EnableRetry
 @EnableAsync
 @ComponentScan(
 	basePackages = "app",

--- a/src/main/java/app/domain/user/UserController.java
+++ b/src/main/java/app/domain/user/UserController.java
@@ -1,8 +1,8 @@
 package app.domain.user;
 
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,8 +43,8 @@ public class UserController {
 
 	@GetMapping("/info")
 	@Operation(summary = "회원 정보 조회 API", description = "현재 로그인된 사용자의 정보를 조회합니다.")
-	public ApiResponse<GetUserInfoResponse> getUserInfo(@RequestParam Long userId) {
-		GetUserInfoResponse response = userService.getUserInfo(userId);
+	public ApiResponse<GetUserInfoResponse> getUserInfo(Authentication authentication) {
+		GetUserInfoResponse response = userService.getUserInfo(authentication);
 		return ApiResponse.onSuccess(UserSuccessStatus.USER_PROFILE_FETCHED, response);
 	}
 }

--- a/src/main/java/app/domain/user/event/UserSignedUpEvent.java
+++ b/src/main/java/app/domain/user/event/UserSignedUpEvent.java
@@ -1,0 +1,13 @@
+package app.domain.user.event;
+
+public class UserSignedUpEvent {
+	private final Long userId;
+
+	public UserSignedUpEvent(Long userId) {
+		this.userId = userId;
+	}
+
+	public Long getUserId() {
+		return userId;
+	}
+}

--- a/src/main/java/app/domain/user/listener/UserEventsListener.java
+++ b/src/main/java/app/domain/user/listener/UserEventsListener.java
@@ -1,0 +1,51 @@
+package app.domain.user.listener;
+
+import feign.FeignException;
+import app.domain.user.client.InternalOrderClient;
+import app.domain.user.event.UserSignedUpEvent;
+import app.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserEventsListener {
+
+	private final InternalOrderClient internalOrderClient;
+
+	@Async
+	@EventListener
+	@Retryable(
+		value = { feign.FeignException.class },
+		maxAttempts = 3,
+		backoff = @Backoff(delay = 2000)
+	)
+	public void handleUserSignedUpEvent(UserSignedUpEvent event) {
+		log.info("회원가입 이벤트 수신 (비동기 처리 시작): userId={}", event.getUserId());
+
+		try {
+			ApiResponse<String> response = internalOrderClient.createCart(event.getUserId());
+
+			if (response == null || !response.isSuccess()) {
+				log.error("신규 회원 장바구니 생성 실패: userId={}, 응답: {}", event.getUserId(), response);
+			} else {
+				log.info("신규 회원 장바구니 생성 완료: userId={}", event.getUserId());
+			}
+		} catch (Exception e) {
+			log.error("장바구니 생성 API 호출 중 예외 발생: userId={}", event.getUserId(), e);
+		}
+	}
+
+	@Recover
+	public void recover(feign.FeignException e, UserSignedUpEvent event) {
+		log.error("최종 실패 - 장바구니 생성 실패: userId={}, error={}", event.getUserId(), e.getMessage());
+	}
+}

--- a/src/main/java/app/global/config/SecurityConfig.java
+++ b/src/main/java/app/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package app.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -9,7 +10,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import lombok.RequiredArgsConstructor;
 
-@Configuration
+@Configuration("userSecurityConfig")
 @RequiredArgsConstructor
 @EnableMethodSecurity
 public class SecurityConfig {
@@ -25,7 +26,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())          // CSRF 비활성화
 			.authorizeHttpRequests(auth -> auth
 				.anyRequest().permitAll()          // 모든 요청 허용
-			);
+			).oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
 		return http.build();
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,12 @@ spring:
       password: ${REDIS_PASSWORD}
       database: 0
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: http://localhost:8083/oauth/jwks
+
 jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-validity-in-milliseconds: 3600000 # 1 hour


### PR DESCRIPTION
## 🔥 Related Issues

- close #7 

## 👍 작업 내용

- [x] ~ common-security 커스텀 라이브러리 활용해 auth로부터 userId추출하는 **getInfo**로 수정
- [x] ~ 회원가입 로직에서 카트 생성에 대한 에러 처리로, 비동기 이벤트를 추가함(kafka 말고 rest로)

## ✅ PR Point

- 유효하지 않은 사용자에 대해 장바구니(cart)를 생성하려고 해서 DB 무결성 오류가 발생한 상황이라, 
- security filter chain에 oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults())); 를 하지 않는다면 jwt가 비어서 나옴
- 비동기 로직 처리할 때, 실패하는 경우 재시도는 어떤 주기를 갖고 진행할 것인지. 최종 실패였을 때는 어떻게 진행할 것인지 고민해야 함 : 현재 재시도는 임의로 해둔 상태, 최종 실패에 대해 논의 필요
- 지속적으로 실패가 발생할 때, 개발자가 이를 빠르게 인지하고 대응해야 하는데 모니터링 시스템에 대한 논의 필요
